### PR TITLE
Implement '/system/namespaces'.

### DIFF
--- a/pkg/server/namespaces.go
+++ b/pkg/server/namespaces.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func makeListNamespaceHandler(defaultNamespace string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		res, _ := json.Marshal([]string{defaultNamespace})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(res)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	clientset "github.com/openfaas-incubator/openfaas-operator/pkg/client/clientset/versioned"
-	"github.com/openfaas/faas-provider"
+	bootstrap "github.com/openfaas/faas-provider"
 	"github.com/openfaas/faas-provider/types"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	kubeinformers "k8s.io/client-go/informers"
@@ -64,16 +64,17 @@ func Start(client clientset.Interface,
 	deploymentLister := deploymentInformer.Lister().Deployments(functionNamespace)
 
 	bootstrapHandlers := types.FaaSHandlers{
-		FunctionProxy:  makeProxy(functionNamespace, time.Duration(readTimeout)*time.Second),
-		DeleteHandler:  makeDeleteHandler(functionNamespace, client),
-		DeployHandler:  makeApplyHandler(functionNamespace, client),
-		FunctionReader: makeListHandler(functionNamespace, client, deploymentLister),
-		ReplicaReader:  makeReplicaReader(functionNamespace, client, kube, deploymentLister),
-		ReplicaUpdater: makeReplicaHandler(functionNamespace, client),
-		UpdateHandler:  makeApplyHandler(functionNamespace, client),
-		HealthHandler:  makeHealthHandler(),
-		InfoHandler:    makeInfoHandler(),
-		SecretHandler:  makeSecretHandler(functionNamespace, kube),
+		FunctionProxy:        makeProxy(functionNamespace, time.Duration(readTimeout)*time.Second),
+		DeleteHandler:        makeDeleteHandler(functionNamespace, client),
+		DeployHandler:        makeApplyHandler(functionNamespace, client),
+		FunctionReader:       makeListHandler(functionNamespace, client, deploymentLister),
+		ReplicaReader:        makeReplicaReader(functionNamespace, client, kube, deploymentLister),
+		ReplicaUpdater:       makeReplicaHandler(functionNamespace, client),
+		UpdateHandler:        makeApplyHandler(functionNamespace, client),
+		HealthHandler:        makeHealthHandler(),
+		InfoHandler:          makeInfoHandler(),
+		SecretHandler:        makeSecretHandler(functionNamespace, kube),
+		ListNamespaceHandler: makeListNamespaceHandler(functionNamespace),
 	}
 
 	bootstrapConfig := types.FaaSConfig{


### PR DESCRIPTION
This PR implements `/system/namespaces` so that applications based on https://github.com/openfaas-incubator/connector-sdk can actually run.