### PR TITLE
Introduce a '--configure-security-context' flag.

### DIFF
--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -118,9 +118,7 @@ func newDeployment(
 		deploymentSpec.Spec.Template.Spec.ServiceAccountName = serviceAccount
 	}
 
-	factory.ConfigureReadOnlyRootFilesystem(function, deploymentSpec)
-	factory.ConfigureContainerUserID(deploymentSpec)
-	factory.ConfigureSecurityContext(deploymentSpec)
+	factory.ConfigureSecurityContext(function, deploymentSpec)
 
 	if err := UpdateSecrets(function, deploymentSpec, existingSecrets); err != nil {
 		glog.Warningf("Function %s secrets update failed: %v",

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -63,7 +63,7 @@ func Test_newDeployment(t *testing.T) {
 				TimeoutSeconds:      3,
 				InitialDelaySeconds: 0,
 			},
-		})
+		}, true)
 
 	secrets := map[string]*corev1.Secret{}
 
@@ -89,8 +89,8 @@ func Test_newDeployment(t *testing.T) {
 		t.Fail()
 	}
 
-	if *(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser) != k8s.SecurityContextUserID {
-		t.Errorf("RunAsUser should be %v", k8s.SecurityContextUserID)
+	if *(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser) != runAsUser {
+		t.Errorf("RunAsUser should be %v", runAsUser)
 		t.Fail()
 	}
 


### PR DESCRIPTION
This PR introduces a `--configure-security-context` flag that allows for disabling configuration of the restrictive security context that otherwise is set in all functions.